### PR TITLE
chore: define uv version once in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,8 @@
 ---
 fail_fast: true
 
+.uv_version: &uv_version uv==0.9.5
+
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 
@@ -77,7 +79,7 @@ repos:
         language: python
         pass_filenames: false
         types_or: [yaml]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: pydocstringformatter
@@ -85,7 +87,7 @@ repos:
         entry: uv run --extra=dev pydocstringformatter
         language: python
         types_or: [python]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: shellcheck
@@ -93,7 +95,7 @@ repos:
         entry: uv run --extra=dev shellcheck --shell=bash
         language: python
         types_or: [shell]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: shellcheck-docs
@@ -102,7 +104,7 @@ repos:
           --language=console --command="shellcheck --shell=bash"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: shfmt
@@ -110,7 +112,7 @@ repos:
         entry: uv run --extra=dev shfmt --write --space-redirects --indent=4
         language: python
         types_or: [shell]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: shfmt-docs
@@ -119,7 +121,7 @@ repos:
           --no-pad-file --command="shfmt --write --space-redirects --indent=4"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: doc8
@@ -127,7 +129,7 @@ repos:
         entry: uv run --extra=dev -m doc8
         language: python
         types_or: [rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: pyproject-fmt-fix
@@ -136,7 +138,7 @@ repos:
         language: python
         types_or: [toml]
         files: pyproject.toml
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: yamlfix
@@ -144,7 +146,7 @@ repos:
         entry: uv run --extra=dev yamlfix
         language: python
         types_or: [yaml]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: zizmor
@@ -153,7 +155,7 @@ repos:
         language: python
         pass_filenames: false
         types_or: [yaml]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
       - id: sphinx-lint
@@ -161,5 +163,5 @@ repos:
         entry: uv run --extra=dev sphinx-lint --enable=all --disable=line-too-long
         language: python
         types_or: [rst]
-        additional_dependencies: [uv==0.9.5]
+        additional_dependencies: [*uv_version]
         stages: [pre-commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -79,7 +79,8 @@ repos:
         language: python
         pass_filenames: false
         types_or: [yaml]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: pydocstringformatter
@@ -87,7 +88,8 @@ repos:
         entry: uv run --extra=dev pydocstringformatter
         language: python
         types_or: [python]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: shellcheck
@@ -95,7 +97,8 @@ repos:
         entry: uv run --extra=dev shellcheck --shell=bash
         language: python
         types_or: [shell]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: shellcheck-docs
@@ -104,7 +107,8 @@ repos:
           --language=console --command="shellcheck --shell=bash"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: shfmt
@@ -112,7 +116,8 @@ repos:
         entry: uv run --extra=dev shfmt --write --space-redirects --indent=4
         language: python
         types_or: [shell]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: shfmt-docs
@@ -121,7 +126,8 @@ repos:
           --no-pad-file --command="shfmt --write --space-redirects --indent=4"
         language: python
         types_or: [markdown, rst]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: doc8
@@ -129,7 +135,8 @@ repos:
         entry: uv run --extra=dev -m doc8
         language: python
         types_or: [rst]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: pyproject-fmt-fix
@@ -138,7 +145,8 @@ repos:
         language: python
         types_or: [toml]
         files: pyproject.toml
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: yamlfix
@@ -146,7 +154,8 @@ repos:
         entry: uv run --extra=dev yamlfix
         language: python
         types_or: [yaml]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: zizmor
@@ -155,7 +164,8 @@ repos:
         language: python
         pass_filenames: false
         types_or: [yaml]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]
 
       - id: sphinx-lint
@@ -163,5 +173,6 @@ repos:
         entry: uv run --extra=dev sphinx-lint --enable=all --disable=line-too-long
         language: python
         types_or: [rst]
-        additional_dependencies: [*uv_version]
+        additional_dependencies:
+          - *uv_version
         stages: [pre-commit]


### PR DESCRIPTION
Matches the pattern from [literalizer](https://github.com/adamtheturtle/literalizer): a YAML anchor `.uv_version` so the uv pin is declared once and referenced as `*uv_version` in each hook's `additional_dependencies`.

`pre-commit validate-config` may warn about an unexpected root key `.uv_version`; that is expected and matches literalizer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only refactor: deduplicates the `uv` version pin in `.pre-commit-config.yaml` without changing hook commands or behavior, aside from potential `pre-commit validate-config` warnings about the extra root key.
> 
> **Overview**
> Refactors `.pre-commit-config.yaml` to define the pinned `uv==0.9.5` version once via a YAML anchor (`.uv_version: &uv_version ...`) and reuse it (`*uv_version`) across all local hooks’ `additional_dependencies`.
> 
> This reduces duplication while keeping the same `uv run`-based hook entries and tooling set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c890534a0429668d9d2da312ac02cfc1d4b5003. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->