### PR TITLE
Use prek action with autofix.ci

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,8 @@ updates:
     directory: /
     schedule:
       interval: daily
+
+  - package-ecosystem: pre-commit
+    directory: /
+    schedule:
+      interval: daily

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -1,0 +1,37 @@
+---
+name: autofix.ci
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  autofix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v9.0.0
+
+      - name: Run fixers
+        uses: j178/prek-action@v3.0.0
+        with:
+          prek-version: 0.4.11
+          extra-args: >-
+            --all-files --hook-stage pre-commit --no-fail-fast --verbose
+        env:
+          UV_NO_CACHE: '1'
+          UV_PYTHON: 3.13
+
+      - uses: autofix-ci/action@v1.3.4
+        if: always()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,17 +49,14 @@ jobs:
           UV_PYTHON: ${{ matrix.python-version }}
 
       - name: Lint
-        # Use bash to ensure the step fails if any command fails.
-        # PowerShell does not fail on intermediate command failures by default.
-        shell: bash
-        run: |
-          # pre-commit is the only hook stage
-          uv run --extra=dev prek run --all-files --hook-stage ${{ matrix.hook-stage }} --verbose
+        uses: j178/prek-action@v3.0.0
+        with:
+          prek-version: 0.4.11
+          extra-args: >-
+            --all-files --hook-stage ${{ matrix.hook-stage }} --verbose
         env:
+          UV_NO_CACHE: '1'
           UV_PYTHON: ${{ matrix.python-version }}
-
-      - uses: pre-commit-ci/lite-action@v1.1.0
-        if: always()
 
   completion-lint:
     needs: build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,22 +6,6 @@ fail_fast: true
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 
-ci:
-  # We use system Python, with required dependencies specified in pyproject.toml.
-  # We therefore cannot use those dependencies in pre-commit CI.
-  skip:
-    - actionlint
-    - doc8
-    - pydocstringformatter
-    - pyproject-fmt-fix
-    - shellcheck
-    - shellcheck-docs
-    - shfmt
-    - shfmt-docs
-    - sphinx-lint
-    - yamlfix
-    - zizmor
-
 # This should match the hook stages run in the lint configuration.
 default_install_hook_types: [pre-commit]
 


### PR DESCRIPTION
## Summary

- run the existing lint jobs with `j178/prek-action@v3.0.0` and prek 0.4.11
- add a dedicated autofix.ci producer workflow using `autofix-ci/action@v1.3.4`
- remove legacy pre-commit.ci Lite configuration where present
- let Dependabot update hook revisions through its `pre-commit` ecosystem

Both actions use exact release tags rather than commit SHAs, following the agreed rollout policy.

## Validation

- all changed YAML parses successfully
- `actionlint` passes for both changed workflows
- `zizmor` reports no findings for both changed workflows

Part of [adamtheturtle/Coding-Project-TODOs#8](https://github.com/adamtheturtle/Coding-Project-TODOs/issues/8).

## Before merge

- [ ] Install the autofix.ci GitHub App for this repository
- [ ] Confirm autofix commits are produced on a test pull request
- [ ] Remove the pre-commit.ci GitHub App after the replacement is verified

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and hook tooling only; no application runtime or security logic changes, though autofix.ci needs the GitHub App installed before auto-commits work.
> 
> **Overview**
> **Replaces pre-commit.ci with GitHub Actions–based linting and auto-fixes.**
> 
> Lint jobs now run hooks through **`j178/prek-action`** (prek **0.4.11**) instead of a bash `uv run prek` step, with **`UV_NO_CACHE`** set. The **`pre-commit-ci/lite-action`** step is removed.
> 
> A new **`autofix.ci`** workflow checks out the repo, installs **uv**, runs prek fixers with **`--no-fail-fast`**, then uses **`autofix-ci/action`** to push formatting fixes on PRs and main.
> 
> **Dependabot** gains a **`pre-commit`** ecosystem entry for daily hook revision updates. The **`ci:`** skip list is removed from **`.pre-commit-config.yaml`** because pre-commit.ci is no longer used.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c50b468859195a59a1ca32e9dad35c4e383eb4b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->