### PR TITLE
Lint reStructuredText prose with Vale to ban em dashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,6 @@ uv.lock
 # Ignore Mac DS_Store files
 .DS_Store
 **/.DS_Store
+
+# Vale styles downloaded by ``vale sync``
+styles/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -114,6 +114,33 @@ repos:
           - *uv_version
         stages: [pre-commit]
 
+      # Vale enforces prose style rules, such as banning em dashes, in
+      # reStructuredText files.
+      # The rules come from the ``ClearProse`` package pinned in ``.vale.ini``,
+      # which ``vale sync`` downloads into the (gitignored) ``styles``
+      # directory.
+      # Vale needs ``rst2html`` from Docutils on the ``PATH`` to parse
+      # reStructuredText.
+      - id: vale-sync
+        name: vale sync
+        entry: uv run --extra=dev vale sync
+        language: python
+        pass_filenames: false
+        types_or: [rst]
+        additional_dependencies:
+          - *uv_version
+        stages: [pre-commit]
+
+      - id: vale
+        name: vale
+        entry: uv run --extra=dev vale
+        language: python
+        types_or: [rst]
+        require_serial: true
+        additional_dependencies:
+          - *uv_version
+        stages: [pre-commit]
+
       - id: doc8
         name: doc8
         entry: uv run --extra=dev -m doc8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -121,12 +121,15 @@ repos:
       # directory.
       # Vale needs ``rst2html`` from Docutils on the ``PATH`` to parse
       # reStructuredText.
+      # ``vale sync`` also runs when ``.vale.ini`` changes, so a package
+      # bump takes effect without waiting for the next reStructuredText
+      # change.
       - id: vale-sync
         name: vale sync
         entry: uv run --extra=dev vale sync
         language: python
         pass_filenames: false
-        types_or: [rst]
+        files: (\.rst$|^\.vale\.ini$)
         additional_dependencies:
           - *uv_version
         stages: [pre-commit]

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,7 @@
+StylesPath = styles
+MinAlertLevel = error
+
+Packages = https://github.com/adamtheturtle/vale-style-clear-prose/releases/download/v1.1.0/ClearProse.zip
+
+[*.rst]
+BasedOnStyles = ClearProse

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ optional-dependencies.dev = [
     "shellcheck-py==0.11.0.1",
     "shfmt-py==4.0.0",
     "sphinx-lint==1.0.2",
+    "vale==3.13.0.0",
     "yamlfix==1.19.1",
     "zizmor==1.29.0",
 ]


### PR DESCRIPTION
Adds Vale as a pre-commit hook so em dashes cannot creep into our reStructuredText.

The rules come from the pinned [ClearProse](https://github.com/adamtheturtle/vale-style-clear-prose) style package (v1.1.0) rather than a hand-written local rule, configured in a new `.vale.ini`; `vale sync` downloads it into a gitignored `styles/` directory before the lint runs. That release ships as a Vale config package, so it carries the `TokenIgnores` pattern that keeps Sphinx role targets such as `:ref:` out of the prose check. `vale==3.13.0.0` is pinned in the dev extra.

Verified locally: `vale` reports no alerts across the tracked `.rst` files, and `prek run` over the changed files passes.

Note that the `vale` PyPI wrapper is behind the upstream binary (3.13.0 against 3.17.1), and 3.13.0 drops the occasional alert: on the ClearProse fixture with seven em dashes it reports six, where 3.17.1 reports all seven. The ban still holds, because a file with an em dash is still reported, but the pin is worth bumping when the wrapper publishes a newer Vale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling-only change to dev dependencies and pre-commit; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds **Vale** to pre-commit so reStructuredText prose is checked against the pinned **ClearProse** style (including an em-dash ban), alongside existing RST linters like `doc8` and `sphinx-lint`.
> 
> A new **`.vale.ini`** points at ClearProse v1.1.0 and applies it to `*.rst`. **`vale sync`** runs before lint (on `.rst` or config changes) and pulls styles into a **gitignored `styles/`** directory. **`vale==3.13.0.0`** is added to the dev extra in **`pyproject.toml`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfbd647ac62bf1595da4922fdbd9bbfc1cdfd518. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->