### PR TITLE
Bump August dependency releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "doccmd==2026.7.19",
+    "doccmd==2026.8.16",
 ]
 optional-dependencies.dev = [
     "actionlint-py==1.7.12.24",


### PR DESCRIPTION
Updates the newly released internal dependencies to their latest August 2026 versions.\n\nThis keeps the development and test toolchain on the released implementations and refreshes the uv lockfile.\n\nValidation: `uv lock` completed successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single dependency version bump with no code or config changes beyond the pin.
> 
> **Overview**
> Bumps the runtime dependency **`doccmd`** from `2026.7.19` to **`2026.8.16`** in `pyproject.toml`, aligning this pre-commit hook repo with the August 2026 **doccmd** release.
> 
> No application logic changes—only the pinned version used when CI installs **doccmd** from PyPI (release tagging still follows the installed **doccmd** version).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 376a64363e3881ff0585dfd557a5dc34fd740a8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->